### PR TITLE
fix: oneclick delete

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5467,7 +5467,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/TransbankDevelopers/transbank-sdk-php",
-                "reference": "bf1da9443773408217f12b68897e767e8307468b"
+                "reference": "5a9d212cd821be1ed58e6cef37b499e9936aaca7"
             },
             "require": {
                 "ext-curl": "*",
@@ -5477,9 +5477,8 @@
                 "php": ">=8.2"
             },
             "require-dev": {
-                "dms/phpunit-arraysubset-asserts": "^0.2.1",
-                "phpunit/phpunit": "^9",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^11",
+                "squizlabs/php_codesniffer": "^3"
             },
             "type": "library",
             "autoload": {
@@ -5496,6 +5495,11 @@
                     ]
                 }
             },
+            "scripts": {
+                "test": [
+                    "phpunit || true"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
@@ -5506,7 +5510,7 @@
                 "sdk",
                 "transbank"
             ],
-            "time": "2024-07-09T19:52:09+00:00"
+            "time": "2025-02-07T16:08:48+00:00"
         },
         {
             "name": "vlucas/phpdotenv",


### PR DESCRIPTION
This PR Update Transbank SDK Reference for last changes in develop branch, due to error in Oneclick delete method.

Before:
![image](https://github.com/user-attachments/assets/8f615600-e56c-471f-a045-86b0f75e75d3)

Now inscription is deleted successfully.