### PR TITLE
fix: correct descriptions api

### DIFF
--- a/app/Http/Controllers/WebpayPlusMallDeferredController.php
+++ b/app/Http/Controllers/WebpayPlusMallDeferredController.php
@@ -112,8 +112,8 @@ class WebpayPlusMallDeferredController extends Controller
     }
     public function showOperations()
     {
-        $webpayPlusStatus = config('webpayParams.webpay_plus_status');
-        $webpayPlusRefund = config('webpayParams.webpay_plus_refund');
+        $webpayPlusStatus = config('webpayParams.webpay_plus_mall_status');
+        $webpayPlusRefund = config('webpayParams.webpay_plus_mall_refund');
         $webpayPlusCaptured = config('webpayParams.webpay_plus_mall_deferred_captured');
 
         return view('webpay-mall-deferred.api-operations', compact(

--- a/config/webpayParams.php
+++ b/config/webpayParams.php
@@ -413,6 +413,10 @@ return [
       'field' => 'details [].buy_order',
       'value' => 'Orden de compra generada por el comercio hijo para la transacción de pago.',
     ],
+    [
+      'field' => 'details [].balance',
+      'value' => 'Monto restante de la sub-transacción de pago original: monto inicial - monto anulado. Largo máximo: 17'
+    ]
   ],
 
   "oneclick_mall_refund" =>

--- a/resources/views/oneclick-mall-deferred/api-operations.blade.php
+++ b/resources/views/oneclick-mall-deferred/api-operations.blade.php
@@ -22,7 +22,7 @@
     <h2>Obtener estado de una transacción</h2>
     <p>Permite consultar el estado de pago realizado a través de Oneclick. Retorna el resultado de la autorización.
         Puedes revisar más detalles de esta operación en su <a target="_blank"
-            href="https://www.transbankdevelopers.cl/documentacion/oneclick#reversar-o-anular-una-transaccion"
+            href="https://www.transbankdevelopers.cl/documentacion/oneclick#obtener-estado-de-una-transaccion"
             class="tbk-link">documentación</a></p>
 
     <livewire:oneclick-mall-deferred.status />

--- a/resources/views/oneclick-mall-deferred/api-operations.blade.php
+++ b/resources/views/oneclick-mall-deferred/api-operations.blade.php
@@ -10,7 +10,7 @@
     <p>Una vez realizada la inscripción, el comercio puede usar el tbkUser recibido para realizar transacciones. Para
         eso debes usar el método transaction.authorize(). Puedes revisar más detalles de esta operación en su
         <a target="_blank" href="https://www.transbankdevelopers.cl/documentacion/oneclick#autorizar-una-transaccion"
-            class="tbk-link">documentación</a>
+            class="tbk-link">documentación.</a>
     </p>
 
     <livewire:oneclick-mall-deferred.authorize />
@@ -23,7 +23,7 @@
     <p>Permite consultar el estado de pago realizado a través de Oneclick. Retorna el resultado de la autorización.
         Puedes revisar más detalles de esta operación en su <a target="_blank"
             href="https://www.transbankdevelopers.cl/documentacion/oneclick#obtener-estado-de-una-transaccion"
-            class="tbk-link">documentación</a></p>
+            class="tbk-link">documentación.</a></p>
 
     <livewire:oneclick-mall-deferred.status />
 
@@ -35,7 +35,7 @@
     <p>En el caso de que tengas contratada la modalidad de Captura diferida, necesitas llamar al método capture después
         de llamar a authorize para finalizar la transacción. Revisa más detalles sobre esta modalidad en la <a
             target="_blank" class="tbk-link"
-            href="https://www.transbankdevelopers.cl/documentacion/oneclick#capturar-una-transaccion">documentación</a>
+            href="https://www.transbankdevelopers.cl/documentacion/oneclick#capturar-una-transaccion">documentación.</a>
     </p>
 
     <livewire:oneclick-mall-deferred.capture />
@@ -48,7 +48,7 @@
     <p>Esta operación permite a todo comercio habilitado, reversar o anular una transacción que fue generada en
         Oneclick. Puedes revisar más detalles de esta operación en su <a target="_blank"
             href="https://www.transbankdevelopers.cl/documentacion/oneclick#reversar-o-anular-una-transaccion"
-            class="tbk-link">documentación</a>
+            class="tbk-link">documentación.</a>
     </p>
 
     <livewire:oneclick-mall-deferred.refund />

--- a/resources/views/oneclick-mall/api-operations.blade.php
+++ b/resources/views/oneclick-mall/api-operations.blade.php
@@ -10,7 +10,7 @@
     <p>Una vez realizada la inscripción, el comercio puede usar el tbkUser recibido para realizar transacciones. Para
         eso debes usar el método transaction.authorize(). Puedes revisar más detalles de esta operación en su
         <a target="_blank" href="https://www.transbankdevelopers.cl/documentacion/oneclick#autorizar-una-transaccion"
-            class="tbk-link">documentación</a>
+            class="tbk-link">documentación.</a>
     </p>
 
     <livewire:oneclick-mall.authorize />
@@ -23,7 +23,7 @@
     <p>Permite consultar el estado de pago realizado a través de Oneclick. Retorna el resultado de la autorización.
         Puedes revisar más detalles de esta operación en su <a target="_blank"
             href="https://www.transbankdevelopers.cl/documentacion/oneclick#obtener-estado-de-una-transaccion"
-            class="tbk-link">documentación</a></p>
+            class="tbk-link">documentación.</a></p>
 
     <livewire:oneclick-mall.status />
 
@@ -35,7 +35,7 @@
     <p>Esta operación permite a todo comercio habilitado, reversar o anular una transacción que fue generada en
         Oneclick. Puedes revisar más detalles de esta operación en su <a target="_blank"
             href="https://www.transbankdevelopers.cl/documentacion/oneclick#reversar-o-anular-una-transaccion"
-            class="tbk-link">documentación</a>
+            class="tbk-link">documentación.</a>
     </p>
 
     <livewire:oneclick-mall.refund />

--- a/resources/views/oneclick-mall/api-operations.blade.php
+++ b/resources/views/oneclick-mall/api-operations.blade.php
@@ -22,7 +22,7 @@
     <h2>Obtener estado de una transacción</h2>
     <p>Permite consultar el estado de pago realizado a través de Oneclick. Retorna el resultado de la autorización.
         Puedes revisar más detalles de esta operación en su <a target="_blank"
-            href="https://www.transbankdevelopers.cl/documentacion/oneclick#reversar-o-anular-una-transaccion"
+            href="https://www.transbankdevelopers.cl/documentacion/oneclick#obtener-estado-de-una-transaccion"
             class="tbk-link">documentación</a></p>
 
     <livewire:oneclick-mall.status />
@@ -34,7 +34,7 @@
     <h2>Reversar o Anular un pago</h2>
     <p>Esta operación permite a todo comercio habilitado, reversar o anular una transacción que fue generada en
         Oneclick. Puedes revisar más detalles de esta operación en su <a target="_blank"
-            href="https://www.transbankdevelopers.cl/documentacion/oneclick#obtener-estado-de-una-transaccion"
+            href="https://www.transbankdevelopers.cl/documentacion/oneclick#reversar-o-anular-una-transaccion"
             class="tbk-link">documentación</a>
     </p>
 

--- a/resources/views/webpay-deferred/api-operations.blade.php
+++ b/resources/views/webpay-deferred/api-operations.blade.php
@@ -34,7 +34,7 @@
 
     <h2>Reversar o Anular un pago diferido</h2>
     <p>Las transacciones de Webpay se pueden anular o reversar dadas algunas condiciones. Para cualquiera de éstas
-        operaciones se utiliza el mismo servicio web que discernirá si se realizará una reversa o una anulación. para
+        operaciones se utiliza el mismo servicio web que discernirá si se realizará una reversa o una anulación. Para
         mas informacion sobre anulaciones a reversa visite <a target="_blank"
             href="https://www.transbankdevelopers.cl/producto/webpay#anulaciones-y-reversas" class="tbk-link">aqui</a>
     </p>

--- a/resources/views/webpay-deferred/api-operations.blade.php
+++ b/resources/views/webpay-deferred/api-operations.blade.php
@@ -23,7 +23,7 @@
     <p>
         Permite solicitar a Webpay la captura diferida de una transacción con autorización y sin captura simultánea.
         Puedes revisar más detalles de esta operación en su <a target="_blank" class="tbk-link"
-            href="https://www.transbankdevelopers.cl/documentacion/webpay-plus#capturar-una-transaccion">documentación</a>
+            href="https://www.transbankdevelopers.cl/documentacion/webpay-plus#capturar-una-transaccion">documentación.</a>
     </p>
 
     <livewire:webpay-deferred.capture />
@@ -35,8 +35,8 @@
     <h2>Reversar o Anular un pago diferido</h2>
     <p>Las transacciones de Webpay se pueden anular o reversar dadas algunas condiciones. Para cualquiera de éstas
         operaciones se utiliza el mismo servicio web que discernirá si se realizará una reversa o una anulación. Para
-        mas informacion sobre anulaciones a reversa visite <a target="_blank"
-            href="https://www.transbankdevelopers.cl/producto/webpay#anulaciones-y-reversas" class="tbk-link">aqui</a>
+        mas información sobre anulaciones a reversa visite <a target="_blank"
+            href="https://www.transbankdevelopers.cl/producto/webpay#anulaciones-y-reversas" class="tbk-link">aquí.</a>
     </p>
 
     <livewire:webpay-deferred.refund />

--- a/resources/views/webpay-mall-deferred/api-operations.blade.php
+++ b/resources/views/webpay-mall-deferred/api-operations.blade.php
@@ -15,7 +15,7 @@
     </p>
     <p>Puedes revisar más detalles de esta operación en su
         <a target="_blank" class="tbk-link"
-            href="https://www.transbankdevelopers.cl/documentacion/webpay-plus#obtener-estado-de-una-transaccion-mall">documentación</a>
+            href="https://www.transbankdevelopers.cl/documentacion/webpay-plus#obtener-estado-de-una-transaccion-mall">documentación.</a>
     </p>
 
     <livewire:webpay-mall-deferred.status />
@@ -28,7 +28,7 @@
     <p>
         Permite solicitar a Webpay la captura diferida de una transacción con autorización y sin captura simultánea.
         Puedes revisar más detalles de esta operación en su <a target="_blank" class="tbk-link"
-            href="https://www.transbankdevelopers.cl/documentacion/webpay-plus#capturar-una-transaccion-mall">documentación</a>
+            href="https://www.transbankdevelopers.cl/documentacion/webpay-plus#capturar-una-transaccion-mall">documentación.</a>
     </p>
 
     <livewire:webpay-mall-deferred.capture />
@@ -41,7 +41,7 @@
     <p>Las transacciones de Webpay Mall se pueden anular o reversar dadas algunas condiciones. Para cualquiera de éstas
         operaciones se utiliza el mismo servicio web que discernirá si se realizará una reversa o una anulación. Para
         más información sobre anulaciones y reversas visite <a target="_blank"
-            href="https://www.transbankdevelopers.cl/producto/webpay#anulaciones-y-reversas" class="tbk-link">aquí</a>
+            href="https://www.transbankdevelopers.cl/producto/webpay#anulaciones-y-reversas" class="tbk-link">aquí.</a>
     </p>
 
     <livewire:webpay-mall-deferred.refund />

--- a/resources/views/webpay-mall/api-operations.blade.php
+++ b/resources/views/webpay-mall/api-operations.blade.php
@@ -23,7 +23,7 @@
     <p>Las transacciones de Webpay Mall se pueden anular o reversar dadas algunas condiciones. Para cualquiera de éstas
         operaciones se utiliza el mismo servicio web que discernirá si se realizará una reversa o una anulación. Para
         más información sobre anulaciones y reversas visite <a target="_blank"
-            href="https://www.transbankdevelopers.cl/producto/webpay#anulaciones-y-reversas" class="tbk-link">aquí</a>
+            href="https://www.transbankdevelopers.cl/producto/webpay#anulaciones-y-reversas" class="tbk-link">aquí.</a>
     </p>
 
     <livewire:webpay-mall.refund />

--- a/resources/views/webpay/api-operations.blade.php
+++ b/resources/views/webpay/api-operations.blade.php
@@ -21,7 +21,7 @@
 
     <h2>Reversar o Anular un pago</h2>
     <p>Las transacciones de Webpay se pueden anular o reversar dadas algunas condiciones. Para cualquiera de éstas
-        operaciones se utiliza el mismo servicio web que discernirá si se realizará una reversa o una anulación. para
+        operaciones se utiliza el mismo servicio web que discernirá si se realizará una reversa o una anulación. Para
         mas informacion sobre anulaciones a reversa visite <a target="_blank"
             href="https://www.transbankdevelopers.cl/producto/webpay#anulaciones-y-reversas" class="tbk-link">aqui</a>
     </p>

--- a/resources/views/webpay/api-operations.blade.php
+++ b/resources/views/webpay/api-operations.blade.php
@@ -22,8 +22,8 @@
     <h2>Reversar o Anular un pago</h2>
     <p>Las transacciones de Webpay se pueden anular o reversar dadas algunas condiciones. Para cualquiera de éstas
         operaciones se utiliza el mismo servicio web que discernirá si se realizará una reversa o una anulación. Para
-        mas informacion sobre anulaciones a reversa visite <a target="_blank"
-            href="https://www.transbankdevelopers.cl/producto/webpay#anulaciones-y-reversas" class="tbk-link">aqui</a>
+        mas información sobre anulaciones a reversa visite <a target="_blank"
+            href="https://www.transbankdevelopers.cl/producto/webpay#anulaciones-y-reversas" class="tbk-link">aquí.</a>
     </p>
 
     <livewire:webpay.refund />


### PR DESCRIPTION
This PR corrects spelling, links and tables shown to describe different API operations in the project. Specifically:

1. Webpay plus: Spelling in refund description.
2. Webpay plus deferred: Spelling in Refund description and table shown for Status method.
3. Oneclick mall: Links to documentation for Status and Refund methods.
4. Oneclick mall deferred: Link to documentation and table shown for Status method