### PR TITLE
fix: return url snippet

### DIFF
--- a/app/Http/Controllers/WebpayController.php
+++ b/app/Http/Controllers/WebpayController.php
@@ -58,7 +58,11 @@ class WebpayController extends Controller
             elseif ($request->exists("token_ws")) {
                 $resp = $this->transaction->commit($request["token_ws"]);
                 $view = 'webpay.commit';
-                $data = ["resp" => $resp, "token" => $request["token_ws"]];
+                $data = [
+                    "resp" => $resp,
+                    "token" => $request["token_ws"],
+                    "returnUrl" => url('/') . '/webpay-plus/commit'
+                ];
             }
             return view($view, $data);
         } catch (\Exception $e) {

--- a/app/Http/Controllers/WebpayPlusDeferredController.php
+++ b/app/Http/Controllers/WebpayPlusDeferredController.php
@@ -56,7 +56,11 @@ class WebpayPlusDeferredController extends Controller
             elseif ($request->exists("token_ws")) {
                 $resp = $this->transaction->commit($request["token_ws"]);
                 $view = 'webpay-deferred.commit';
-                $data = ["resp" => $resp, "token" => $request["token_ws"]];
+                $data = [
+                    "resp" => $resp,
+                    "token" => $request["token_ws"],
+                    "returnUrl" => url('/') . '/webpay-plus-diferido/commit'
+                ];
             }
             return view($view, $data);
         } catch (\Exception $e) {

--- a/app/Http/Controllers/WebpayPlusMallController.php
+++ b/app/Http/Controllers/WebpayPlusMallController.php
@@ -69,7 +69,11 @@ class WebpayPlusMallController extends Controller
             elseif ($request->exists("token_ws")) {
                 $resp = $this->mallTransaction->commit($request["token_ws"]);
                 $view = 'webpay-mall.commit';
-                $data = ["resp" => $resp, "token" => $request["token_ws"]];
+                $data = [
+                    "resp" => $resp,
+                    "token" => $request["token_ws"],
+                    "returnUrl" => url('/') . '/webpay-mall/commit'
+                ];
             }
             return view($view, $data);
         } catch (\Exception $e) {

--- a/app/Http/Controllers/WebpayPlusMallDeferredController.php
+++ b/app/Http/Controllers/WebpayPlusMallDeferredController.php
@@ -69,7 +69,11 @@ class WebpayPlusMallDeferredController extends Controller
             elseif ($request->exists("token_ws")) {
                 $resp = $this->mallTransaction->commit($request["token_ws"]);
                 $view = 'webpay-mall-deferred.commit';
-                $data = ["resp" => $resp, "token" => $request["token_ws"]];
+                $data = [
+                    "resp" => $resp,
+                    "token" => $request["token_ws"],
+                    "returnUrl" => url('/') . '/webpay-mall-diferido/commit'
+                ];
             }
             return view($view, $data);
         } catch (\Exception $e) {

--- a/resources/views/webpay-deferred/commit.blade.php
+++ b/resources/views/webpay-deferred/commit.blade.php
@@ -34,7 +34,7 @@
         Después de completar el flujo en el formulario de pago, recibirás un GET con la siguiente
         información:
     </p>
-    <x-snippet>(returnUrl)?token_ws={{ $token }} </x-snippet>
+    <x-snippet :content="$returnUrl . '?token_ws=' . $token" />
 
     <h2 id="request">Paso 2 - Petición:</h2>
     <p class="mb-32">

--- a/resources/views/webpay-mall-deferred/commit.blade.php
+++ b/resources/views/webpay-mall-deferred/commit.blade.php
@@ -36,7 +36,7 @@
             información:
         </p>
     </ul>
-    <x-snippet>(returnUrl)?token_ws={{ $token }} </x-snippet>
+    <x-snippet :content="$returnUrl . '?token_ws=' . $token" />
 
     <h2 id="request">Paso 2 - Petición:</h2>
     <p class="mb-32">

--- a/resources/views/webpay-mall/commit.blade.php
+++ b/resources/views/webpay-mall/commit.blade.php
@@ -36,7 +36,7 @@
             información:
         </p>
     </ul>
-    <x-snippet>(returnUrl)?token_ws={{ $token }} </x-snippet>
+    <x-snippet :content="$returnUrl . '?token_ws=' . $token" />
 
     <h2 id="request">Paso 2 - Petición:</h2>
     <p class="mb-32">

--- a/resources/views/webpay/commit.blade.php
+++ b/resources/views/webpay/commit.blade.php
@@ -36,7 +36,7 @@
             información:
         </p>
     </ul>
-    <x-snippet>(returnUrl)?token_ws={{ $token }} </x-snippet>
+    <x-snippet :content="$returnUrl . '?token_ws=' . $token" />
 
     <h2 id="request">Paso 2 - Petición:</h2>
     <p class="mb-32">


### PR DESCRIPTION
This PR fixes the first snippet at the commit step where should be shown the returnUrl to the following products:
- Webpay Plus
- Webpay Plus Mall
- Webpay Plus Deferred
- Webpay Plus Mall Deferred

## Tests

### Before:

![image](https://github.com/user-attachments/assets/f2756fba-52cd-4ed2-b84e-49db410d9a1c)

### After:

![Captura de pantalla 2025-06-26 a la(s) 3 54 02 p m](https://github.com/user-attachments/assets/7d06288c-5fa5-4fe4-84c5-2ad24b5eb98f)
