### PR TITLE
TBK-338 feat: update snippet position in delete inscription page

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,7 @@
 FROM mcr.microsoft.com/devcontainers/php:1-8.2-bookworm
 
+USER root
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TERM=xterm
 ENV SHELL=/bin/zsh
@@ -11,6 +13,9 @@ RUN rm -f /etc/apt/sources.list.d/yarn.list \
         libsqlite3-dev \
         libzip-dev \
         unzip \
+        ripgrep \
     && docker-php-ext-install pdo_sqlite zip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,13 @@
 {
     "name": "Transbank SDK PHP Example",
-    "dockerComposeFile": "docker-compose.yml",
-    "service": "dev",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-    "remoteUser": "root",
+    "remoteUser": "vscode",
     "postCreateCommand": "bash /workspaces/${localWorkspaceFolderBasename}/.devcontainer/post-create.sh",
-    "shutdownAction": "stopCompose",
+    "shutdownAction": "stopContainer",
     "forwardPorts": [
         8000,
         5173
@@ -58,6 +60,7 @@
                 "extensions.autoUpdate": false,
                 "extensions.autoCheckUpdates": false,
                 "extensions.ignoreRecommendations": true,
+                "todo-tree.ripgrep.ripgrep": "/usr/bin/rg",
                 "remote.containers.installRecommendedExtensions": false,
                 "settingsSync.enabled": false,
                 "files.watcherExclude": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
         }
     },
     "mounts": [
-        "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
+        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
     ],
     "features": {
         "ghcr.io/devcontainers/features/node:1": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,8 +1,0 @@
-services:
-  dev:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    command: sleep infinity
-    volumes:
-      - ../..:/workspaces:cached

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+
+## pnpm
+.pnpm-store

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/resources/views/oneclick-mall/delete.blade.php
+++ b/resources/views/oneclick-mall/delete.blade.php
@@ -30,6 +30,8 @@
         realizado de manera exitosa.
     </p>
 
+    <x-snippet :content="$resp" />
+
     <p class="mb-32">
         En el caso de que no se encuentre el "userName" o el "tbkUser", Transbank responderá con un status code 404 (Not
         Found), y el SDK lanzará una excepción del tipo InscriptionDeleteException.
@@ -40,7 +42,5 @@
         asociado. ¡Gracias por confiar en Transbank para tus operaciones seguras! Si tienes alguna pregunta, estamos
         aquí para ayudarte
     </p>
-
-    <x-snippet :content="$resp" />
 
 </x-layout>


### PR DESCRIPTION
This PR moves the delete-inscription snippet to a better position in the page and updates the devcontainer setup to use a Dockerfile-based configuration with the correct vscode user and SSH mount path. It also adds the pnpm workspace setting needed to allow esbuild builds.

<img width="1920" height="1439" alt="image" src="https://github.com/user-attachments/assets/3ca48986-7763-4bd5-ae82-67c582872558" />
